### PR TITLE
Fix race condition on outfile permissions

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -105,15 +105,16 @@ func (a *Adapter) writeOutput() error {
 		return err
 	}
 
+	err = os.Chmod(a.output, 0666)
+	if err != nil {
+		return err
+	}
+
 	err = os.Rename(tmpfile.Name(), a.output)
 	if err != nil {
 		return err
 	}
 
-	err = os.Chmod(a.output, 0666)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/adapter.go
+++ b/adapter.go
@@ -105,7 +105,7 @@ func (a *Adapter) writeOutput() error {
 		return err
 	}
 
-	err = os.Chmod(a.output, 0666)
+	err = os.Chmod(a.output, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
By setting the permissions before renaming, the permissions on the file read by Prometheus remain consistent.

Closes: #15