### PR TITLE
Make outfile not writable by group/world

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -105,15 +105,16 @@ func (a *Adapter) writeOutput() error {
 		return err
 	}
 
+	err = os.Chmod(a.output, 0666)
+	if err != nil {
+		return err
+	}
+
 	err = os.Rename(tmpfile.Name(), a.output)
 	if err != nil {
 		return err
 	}
 
-	err = os.Chmod(a.output, 0666)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/adapter.go
+++ b/adapter.go
@@ -105,7 +105,7 @@ func (a *Adapter) writeOutput() error {
 		return err
 	}
 
-	err = os.Chmod(a.output, 0666)
+	err = os.Chmod(a.output, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently based on top #16, because they touch the same code block.

Only packet-sd should need to write this file, and consumers should only
be able to read this file.