### PR TITLE
ci: Add GHAs for PR validation and semantic release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Generate Next Release
+# This workflow will generate changelog and release notes.
+# Source: https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/.github/workflows/release.yml
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.19.x
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          semantic_version: 19.0.5
+          extra_plugins: |
+            @semantic-release/exec@6.0.3
+            @semantic-release/git@10.0.0
+            conventional-changelog-conventionalcommits@4.6.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: equinix-labs@auto-commit-workflow
+          GIT_AUTHOR_EMAIL: bot@equinix.noreply.github.com
+          GIT_COMMITTER_NAME: equinix-labs@auto-commit-workflow
+          GIT_COMMITTER_EMAIL: bot@equinix.noreply.github.com
+          RELEASE_REQUESTER: "@${{ github.event.sender.login }}"

--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -1,0 +1,45 @@
+name: "Validate PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,41 @@
+{
+    "branches": [
+      "master"
+    ],
+    "ci": false,
+    "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
+      [
+        "@semantic-release/github",
+        {
+          "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
+          "labels": false,
+          "releasedLabels": false
+        }
+      ],
+      [
+        "@semantic-release/exec",
+        {
+          "prepareCmd": "echo -n '${nextRelease.version}' > version && make generate-all"
+        }
+      ],
+      [
+        "@semantic-release/git",
+        {
+          "message": "ci: regenerate code for version ${nextRelease.version} triggered by ${process.env.RELEASE_REQUESTER}",
+          "assets": ["."]
+        }
+      ]
+    ]
+  }


### PR DESCRIPTION
This PR adds GHAs for semantic PR title check and release `on: workflow_dispatch` :crossed_fingers:

