### PR TITLE
fix: Apply chmod to tmpfile, not the outfile

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -105,7 +105,7 @@ func (a *Adapter) writeOutput() error {
 		return err
 	}
 
-	err = os.Chmod(a.output, 0644)
+	err = os.Chmod(tmpfile.Name(), 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This was missed during review, so the permissions are now too narrow.

Tested and the permissions are now correct.